### PR TITLE
Feat: add size arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This extension provides support for
 [academicons](https://jpswalsh.github.io/academicons/). Icons can be used in
 HTML documents only.
 
-The code is adapted from the [fontawesome](https://github.com/quarto-ext/fontawesome) extension
+The code is adapted from the [fontawesome](https://github.com/quarto-ext/fontawesome) extension.
 
 ## Installing
 
-```
-$ quarto install extension schochastics/academicons
+```bash
+quarto install extension schochastics/academicons
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -19,19 +19,65 @@ If you're using version control, you will want to check in this directory.
 
 To embed an icon, use the `{{{< ai >}}}` shortcode. For example:
 
-```
+```default
 {{< ai arxiv >}} 
 {{< ai google-scholar >}}
 {{< ai open-access }}
+{{< ai open-access size=5x >}}
 ```
 
 You can browse all of the available icons here:
 
 <https://jpswalsh.github.io/academicons/>
 
+### Sizing Icons
+
+This extension provides relative, literal, and LaTeX-style sizing for icons.  
+When the size is invalid, no size changes are made.
+
+- Relative sizing: `{{< ai open-access size=2xl >}}`.
+
+  | Relative Sizing Class | Font Size | Equivalent in Pixels |
+  |-----------------------|-----------|----------------------|
+  | 2xs                   | 0.625em   | 10px                 |
+  | xs                    | 0.75em    | 12px                 |
+  | sm                    | 0.875em   | 14px                 |
+  | lg                    | 1.25em    | 20px                 |
+  | xl                    | 1.5em     | 24px                 |
+  | 2xl                   | 2em       | 32px                 |
+
+- Literal sizing: `{{< ai open-access size=5x >}}`.
+
+  | Literal Sizing Class | Font Size |
+  |----------------------|-----------|
+  | 1x                   | 1em       |
+  | 2x                   | 2em       |
+  | 3x                   | 3em       |
+  | 4x                   | 4em       |
+  | 5x                   | 5em       |
+  | 6x                   | 6em       |
+  | 7x                   | 7em       |
+  | 8x                   | 8em       |
+  | 9x                   | 9em       |
+  | 10x                  | 10em      |
+
+- LaTeX-style sizing: `{{< ai open-access size=Huge >}}`.
+
+  | Sizing Command                   | Font Size (HTML) |
+  | -------------------------------- | ---------------- |
+  | tiny (= `\tiny`)                 | 0.5em            |
+  | scriptsize (= `\scriptsize`)     | 0.7em            |
+  | footnotesize (= `\footnotesize`) | 0.8em            |
+  | small (= `\small`)               | 0.9em            |
+  | normalsize (= `\normalsize`)     | 1em              |
+  | large (= `\large`)               | 1.25em           |
+  | Large (= `\Large`)               | 1.5em            |
+  | LARGE (= `\LARGE`)               | 1.75em           |
+  | huge (= `\huge`)                 | 2em              |
+  | Huge (= `\Huge`)                 | 2.5em            |
+
 ## Example
 
 Here is the source code for a minimal example: [example.qmd](example.qmd)
 
 This is the output of `example.qmd` for [HTML](https://schochastics.github.io/academicons/).
-

--- a/_extensions/academicons/academicons.lua
+++ b/_extensions/academicons/academicons.lua
@@ -5,7 +5,7 @@
 function ensureHtmlDeps()
   quarto.doc.addHtmlDependency({
     name = 'academicons',
-    version = '0.1.0',
+    version = '1.9.2',
     stylesheets = {'assets/css/all.css'}
   })
 end

--- a/_extensions/academicons/academicons.lua
+++ b/_extensions/academicons/academicons.lua
@@ -2,12 +2,31 @@
 --   quarto.doc.useLatexPackage("academicons")
 -- end
 
-function ensureHtmlDeps()
+local function ensureHtmlDeps()
   quarto.doc.addHtmlDependency({
-    name = 'academicons',
-    version = '1.9.2',
-    stylesheets = {'assets/css/all.css'}
+    name = "academicons",
+    version = "1.9.2",
+    stylesheets = {"assets/css/all.css", "assets/css/size.css"}
   })
+end
+
+local function isEmpty(s)
+  return s == nil or s == ''
+end
+
+local function isValidSize(size)
+  local validSizes = {
+    "tiny", "scriptsize", "footnotesize", "small", "normalsize",
+    "large", "Large", "LARGE", "huge", "Huge",
+    "1x", "2x", "3x", "4x", "5x", "6x", "7x", "8x", "9x", "10x",
+    "2xs", "xs", "sm", "lg", "xl", "2xl"
+  }
+  for _, v in ipairs(validSizes) do
+    if v == size then
+      return " ai-" .. size
+    end
+  end
+  return ""
 end
 
 return {
@@ -20,10 +39,22 @@ return {
       icon = pandoc.utils.stringify(args[2])
     end
 
+    local size = isValidSize(pandoc.utils.stringify(kwargs["size"]))
+
     -- detect html (excluding epub)
     if quarto.doc.isFormat("html:js") then
       ensureHtmlDeps()
-      return pandoc.RawInline('html', "<i class=\"ai " .. group .. " ai-" .. icon .. "\"></i>")
+      if isEmpty(size) then
+        return pandoc.RawInline(
+          'html',
+          "<i class=\"ai " .. group .. " ai-" .. icon .. "\"></i>"
+        )
+      else
+        return pandoc.RawInline(
+          'html',
+          "<i class=\"ai " .. group .. " ai-" .. icon .. size .. "\"></i>"
+        )
+      end
     -- detect pdf / beamer / latex / etc
     -- elseif quarto.doc.isFormat("pdf") then
     --   ensureLatexDeps()

--- a/_extensions/academicons/assets/css/size.css
+++ b/_extensions/academicons/assets/css/size.css
@@ -1,0 +1,115 @@
+.ai-tiny {
+  font-size: 0.5em;
+}
+
+.ai-scriptsize {
+  font-size: 0.7em;
+}
+
+.ai-footnotesize {
+  font-size: 0.8em;
+}
+
+.ai-small {
+  font-size: 0.9em;
+}
+
+.ai-normalsize {
+  font-size: 1em;
+}
+
+.ai-large {
+  font-size: 1.2em;
+}
+
+.ai-Large {
+  font-size: 1.5em;
+}
+
+.ai-LARGE {
+  font-size: 1.75em;
+}
+
+.ai-huge {
+  font-size: 2em;
+}
+
+.ai-Huge {
+  font-size: 2.5em;
+}
+
+.ai-1x {
+  font-size: 1em;
+}
+
+.ai-2x {
+  font-size: 2em;
+}
+
+.ai-3x {
+  font-size: 3em;
+}
+
+.ai-4x {
+  font-size: 4em;
+}
+
+.ai-5x {
+  font-size: 5em;
+}
+
+.ai-6x {
+  font-size: 6em;
+}
+
+.ai-7x {
+  font-size: 7em;
+}
+
+.ai-8x {
+  font-size: 8em;
+}
+
+.ai-9x {
+  font-size: 9em;
+}
+
+.ai-10x {
+  font-size: 10em;
+}
+
+.ai-2xs {
+  font-size: 0.625em;
+  line-height: 0.1em;
+  vertical-align: 0.225em;
+}
+
+.ai-xs {
+  font-size: 0.75em;
+  line-height: 0.08333em;
+  vertical-align: 0.125em;
+}
+
+.ai-sm {
+  font-size: 0.875em;
+  line-height: 0.07143em;
+  vertical-align: 0.05357em;
+}
+
+.ai-lg {
+  font-size: 1.25em;
+  line-height: 0.05em;
+  vertical-align: -0.075em;
+}
+
+.ai-xl {
+  font-size: 1.5em;
+  line-height: 0.04167em;
+  vertical-align: -0.125em;
+}
+
+.ai-2xl {
+  font-size: 2em;
+  line-height: 0.03125em;
+  vertical-align: -0.1875em;
+}

--- a/example.qmd
+++ b/example.qmd
@@ -1,8 +1,6 @@
 ---
 title: Academicons Quarto Extension
-format:
-   html: default
-   pdf: default
+format: html
 ---
 
 This extension allows you to use academicons in your Quarto HTML documents. It provides an `{{{< ai >}}}` shortcode:

--- a/example.qmd
+++ b/example.qmd
@@ -3,16 +3,23 @@ title: Academicons Quarto Extension
 format: html
 ---
 
-This extension allows you to use academicons in your Quarto HTML documents. It provides an `{{{< ai >}}}` shortcode:
+This extension allows you to use [academicons](https://jpswalsh.github.io/academicons/) in your Quarto HTML documents. It provides an `{{{< ai >}}}` shortcode:
 
-``` markdown
-{{{< ai icon-name >}}}
-```
+- Mandatory `<icon-name>`:
+  ``` markdown
+  {{{< ai <icon-name> >}}}
+  ```
+
+- Optional `<size=...>`:
+  ``` markdown
+  {{{< ai <icon-name> <size=...> >}}}
+  ```
 
 For example:
 
-| Shortcode                       | Icon                        |
-|---------------------------------|-----------------------------|
-| `{{{< ai arxiv >}}}`            | {{< ai arxiv >}}            |
-| `{{{< ai google-scholar >}}}`   | {{< ai google-scholar >}}   |
-| `{{{< ai open-access >}}}`      | {{< ai open-access >}}      |
+| Shortcode                          | Icon                           |
+|------------------------------------|--------------------------------|
+| `{{{< ai arxiv >}}}`               | {{< ai arxiv >}}               |
+| `{{{< ai google-scholar >}}}`      | {{< ai google-scholar >}}      |
+| `{{{< ai open-access >}}}`         | {{< ai open-access >}}         |
+| `{{{< ai open-access size=5x >}}}` | {{< ai open-access size=5x >}} |


### PR DESCRIPTION
This PR brings `size` argument support as it was implemented in the `[fontawesome](https://github.com/quarto-ext/fontawesome)` and `[iconify](https://github.com/mcanouil/quarto-iconify)` extensions, i.e., `{{< ai open-access size=5x >}}`