### PR TITLE
Added pdf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,33 +33,36 @@ You can browse all of the available icons here:
 ### Sizing Icons
 
 This extension provides relative, literal, and LaTeX-style sizing for icons.  
-When the size is invalid, no size changes are made.
+When the size is invalid, no size changes are made. LaTeX-style sizes are automatically
+converted to HTML-style sizing for HTML documents, and _relative_ HTML-styles sizes are
+converted to LaTeX-style sizing for PDF documents. Different sizes can be specified
+for HTML and PDF documents using the `hsize` and `psize` parameters.
 
 - Relative sizing: `{{< ai open-access size=2xl >}}`.
 
   | Relative Sizing Class | Font Size | Equivalent in Pixels |
   | --------------------- | --------- | -------------------- |
-  | 2xs                   | 0.625em   | 10px                 |
-  | xs                    | 0.75em    | 12px                 |
-  | sm                    | 0.875em   | 14px                 |
-  | lg                    | 1.25em    | 20px                 |
-  | xl                    | 1.5em     | 24px                 |
-  | 2xl                   | 2em       | 32px                 |
+  | ai-2xs                | 0.625em   | 10px                 |
+  | ai-xs                 | 0.75em    | 12px                 |
+  | ai-sm                 | 0.875em   | 14px                 |
+  | ai-lg                 | 1.25em    | 20px                 |
+  | ai-xl                 | 1.5em     | 24px                 |
+  | ai-2xl                | 2em       | 32px                 |
 
 - Literal sizing: `{{< ai open-access size=5x >}}`.
 
   | Literal Sizing Class | Font Size |
   | -------------------- | --------- |
-  | 1x                   | 1em       |
-  | 2x                   | 2em       |
-  | 3x                   | 3em       |
-  | 4x                   | 4em       |
-  | 5x                   | 5em       |
-  | 6x                   | 6em       |
-  | 7x                   | 7em       |
-  | 8x                   | 8em       |
-  | 9x                   | 9em       |
-  | 10x                  | 10em      |
+  | ai-1x                | 1em       |
+  | ai-2x                | 2em       |
+  | ai-3x                | 3em       |
+  | ai-4x                | 4em       |
+  | ai-5x                | 5em       |
+  | ai-6x                | 6em       |
+  | ai-7x                | 7em       |
+  | ai-8x                | 8em       |
+  | ai-9x                | 9em       |
+  | ai-10x               | 10em      |
 
 - LaTeX-style sizing: `{{< ai open-access size=Huge >}}`.
 
@@ -76,7 +79,7 @@ When the size is invalid, no size changes are made.
   | huge (= `\huge`)                 | 2em              |
   | Huge (= `\Huge`)                 | 2.5em            |
 
-- CSS-style sizing: `{{< ai open-access size=2em >}}`.
+- Different sizes for HTML and PDF: `{{< ai open-access hsize=xl psize=Large >}}`.
 
 ### Coloring icon
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This extension provides support for
 [academicons](https://jpswalsh.github.io/academicons/) (v1.9.4). Icons can be used in
-HTML documents only.
+HTML  and PDF documents only.
 
 The code is adapted from the [fontawesome](https://github.com/quarto-ext/fontawesome) extension.
 
@@ -38,7 +38,7 @@ When the size is invalid, no size changes are made.
 - Relative sizing: `{{< ai open-access size=2xl >}}`.
 
   | Relative Sizing Class | Font Size | Equivalent in Pixels |
-  |-----------------------|-----------|----------------------|
+  | --------------------- | --------- | -------------------- |
   | 2xs                   | 0.625em   | 10px                 |
   | xs                    | 0.75em    | 12px                 |
   | sm                    | 0.875em   | 14px                 |
@@ -49,7 +49,7 @@ When the size is invalid, no size changes are made.
 - Literal sizing: `{{< ai open-access size=5x >}}`.
 
   | Literal Sizing Class | Font Size |
-  |----------------------|-----------|
+  | -------------------- | --------- |
   | 1x                   | 1em       |
   | 2x                   | 2em       |
   | 3x                   | 3em       |

--- a/README.md
+++ b/README.md
@@ -84,8 +84,11 @@ for HTML and PDF documents using the `hsize` and `psize` parameters.
 ### Coloring icon
 
 The color of the icon can be changed via the `color` parameter.  
-`{{< ai open-access color=red >}}`
+`{{< ai open-access color=red >}}` 
 
+
+Different colors for HTML and PDF can be specified using the `hcolor` and `pcolor` parameters:
+`{{< ai open-access hcolor=red pcolor=blue >}}`
 
 ## Example
 

--- a/_extensions/academicons/_extension.yml
+++ b/_extensions/academicons/_extension.yml
@@ -1,6 +1,6 @@
 title: Support for academicons
 author: David Schoch
-version: 0.3.0
+version: 0.4.0
 contributes:
   shortcodes:
     - academicons.lua

--- a/_extensions/academicons/academicons.lua
+++ b/_extensions/academicons/academicons.lua
@@ -5,7 +5,7 @@
 local function ensureHtmlDeps()
   quarto.doc.addHtmlDependency({
     name = "academicons",
-    version = "1.9.2",
+    version = "1.9.4",
     stylesheets = { "assets/css/all.css", "assets/css/size.css" }
   })
 end

--- a/_extensions/academicons/academicons.lua
+++ b/_extensions/academicons/academicons.lua
@@ -1,9 +1,9 @@
--- function ensureLatexDeps()
---   quarto.doc.useLatexPackage("academicons")
--- end
+function ensureLatexDeps()
+  quarto.doc.use_latex_package("academicons")
+end
 
 local function ensureHtmlDeps()
-  quarto.doc.addHtmlDependency({
+  quarto.doc.add_html_dependency({
     name = "academicons",
     version = "1.9.4",
     stylesheets = { "assets/css/all.css", "assets/css/size.css" }
@@ -16,17 +16,53 @@ end
 
 local function isValidSize(size)
   local validSizes = {
-    "tiny", "scriptsize", "footnotesize", "small", "normalsize",
-    "large", "Large", "LARGE", "huge", "Huge",
-    "1x", "2x", "3x", "4x", "5x", "6x", "7x", "8x", "9x", "10x",
-    "2xs", "xs", "sm", "lg", "xl", "2xl"
+    "tiny",
+    "scriptsize",
+    "footnotesize",
+    "small",
+    "normalsize",
+    "large",
+    "Large",
+    "LARGE",
+    "huge",
+    "Huge"
   }
   for _, v in ipairs(validSizes) do
     if v == size then
-      return " ai-" .. size
+      return size
     end
   end
   return ""
+end
+
+local function convertToLatexSize(size)
+  local sizeMap = {
+    ["2xs"] = "tiny",
+    ["xs"] = "scriptsize",
+    ["sm"] = "small",
+    ["lg"] = "large",
+    ["xl"] = "Large",
+    ["2xl"] = "huge",
+    ["1x"] = "normalsize",
+    ["2x"] = "huge",
+    ["3x"] = "Huge"
+  }
+  return sizeMap[size] or size
+end
+local function convertToHtmlSize(size)
+  local sizeMap = {
+    ["tiny"] = "0.5em",
+    ["scriptsize"] = "0.7em",
+    ["footnotesize"] = "0.8em",
+    ["small"] = "0.9em",
+    ["normalsize"] = "1em",
+    ["large"] = "1.25em",
+    ["Large"] = "1.5em",
+    ["LARGE"] = "1.75em",
+    ["huge"] = "2em",
+    ["Huge"] = "2.5em"
+  }
+  return sizeMap[size] or size
 end
 
 return {
@@ -38,12 +74,13 @@ return {
       icon = pandoc.utils.stringify(args[2])
     end
 
-    local size = isValidSize(pandoc.utils.stringify(kwargs["size"]))
     local color = pandoc.utils.stringify(kwargs["color"])
-    if not isEmpty(color) then
-      color = " style=\"color:" .. color .. "\""
-      --else
-      -- color = " style=\"color:" .. "black"  .. "\""
+
+    local label = pandoc.utils.stringify(kwargs["label"])
+    if isEmpty(label) then
+      label = " aria-label=\"" .. icon .. "\""
+    else
+      label = " aria-label=\"" .. label .. "\""
     end
 
     local title = pandoc.utils.stringify(kwargs["title"])
@@ -51,30 +88,50 @@ return {
       title = " title=\"" .. title .. "\""
     end
 
+    local size = pandoc.utils.stringify(kwargs["size"])
+
+    local hsize = pandoc.utils.stringify(kwargs["hsize"])
+
+    local psize = pandoc.utils.stringify(kwargs["psize"])
+
+
     -- detect html (excluding epub)
     if quarto.doc.isFormat("html:js") then
       ensureHtmlDeps()
-      if isEmpty(size) then
-        local csize = pandoc.utils.stringify(kwargs["size"])
-        if (isEmpty(csize)) then
-          csize = ""
-        else
-          csize = " style=\"font-size:" .. csize .. "\""
-        end
-        return pandoc.RawInline(
-          'html',
-          "<i class=\"ai " .. group .. " ai-" .. icon .. "\"" .. title .. color .. csize .. "></i>"
-        )
-      else
-        return pandoc.RawInline(
-          'html',
-          "<i class=\"ai " .. group .. " ai-" .. icon .. size .. "\"" .. title .. color .. "></i>"
-        )
+      if not isEmpty(hsize) then
+        size = hsize
       end
+      size = convertToHtmlSize(size)
+      if not isEmpty(size) then
+        size = " ai-" .. size
+      end
+      if not isEmpty(color) then
+        color = " style=\"color:" .. color .. "\""
+      end
+      return pandoc.RawInline(
+        'html',
+        "<i class=\"ai " .. group .. " ai-" .. icon .. size .. "\"" .. title .. color .. label .. "></i>"
+      )
       -- detect pdf / beamer / latex / etc
-      -- elseif quarto.doc.isFormat("pdf") then
-      --   ensureLatexDeps()
-      --   return pandoc.RawInline('tex', "\\aiIcon{" .. icon .. "}")
+    elseif quarto.doc.is_format("pdf") then
+      ensureLatexDeps()
+      if not isEmpty(psize) then
+        size = psize
+      end
+      size = isValidSize(convertToLatexSize(size))
+      if not isEmpty(size) then
+        size = "\\" .. size
+      end
+      if not isEmpty(color) then
+        color = "\\color{" .. color .. "}"
+      end
+      icon = icon:gsub("-square", "_SQUARE"):gsub("-", ""):gsub("_SQUARE", "-square")
+
+      if isEmpty(size) and isEmpty(color) then
+        return pandoc.RawInline('tex', "\\aiicon{" .. icon .. "}")
+      else
+        return pandoc.RawInline('tex', "{" .. size .. color .. "\\aiicon{" .. icon .. "}}")
+      end
     else
       return pandoc.Null()
     end

--- a/_extensions/academicons/academicons.lua
+++ b/_extensions/academicons/academicons.lua
@@ -51,16 +51,16 @@ local function convertToLatexSize(size)
 end
 local function convertToHtmlSize(size)
   local sizeMap = {
-    ["tiny"] = "0.5em",
-    ["scriptsize"] = "0.7em",
-    ["footnotesize"] = "0.8em",
-    ["small"] = "0.9em",
-    ["normalsize"] = "1em",
-    ["large"] = "1.25em",
-    ["Large"] = "1.5em",
-    ["LARGE"] = "1.75em",
-    ["huge"] = "2em",
-    ["Huge"] = "2.5em"
+    ["tiny"] = "2xs",
+    ["scriptsize"] = "xs",
+    ["footnotesize"] = "xs",
+    ["small"] = "sm",
+    ["normalsize"] = "1x",
+    ["large"] = "lg",
+    ["Large"] = "xl",
+    ["LARGE"] = "2xl",
+    ["huge"] = "2xl",
+    ["Huge"] = "3x"
   }
   return sizeMap[size] or size
 end
@@ -75,6 +75,8 @@ return {
     end
 
     local color = pandoc.utils.stringify(kwargs["color"])
+    local hcolor = pandoc.utils.stringify(kwargs["hcolor"])
+    local pcolor = pandoc.utils.stringify(kwargs["pcolor"])
 
     local label = pandoc.utils.stringify(kwargs["label"])
     if isEmpty(label) then
@@ -89,9 +91,7 @@ return {
     end
 
     local size = pandoc.utils.stringify(kwargs["size"])
-
     local hsize = pandoc.utils.stringify(kwargs["hsize"])
-
     local psize = pandoc.utils.stringify(kwargs["psize"])
 
 
@@ -104,6 +104,9 @@ return {
       size = convertToHtmlSize(size)
       if not isEmpty(size) then
         size = " ai-" .. size
+      end
+      if not isEmpty(hcolor) then
+        color = hcolor
       end
       if not isEmpty(color) then
         color = " style=\"color:" .. color .. "\""
@@ -121,6 +124,9 @@ return {
       size = isValidSize(convertToLatexSize(size))
       if not isEmpty(size) then
         size = "\\" .. size
+      end
+      if not isEmpty(pcolor) then
+        color = pcolor
       end
       if not isEmpty(color) then
         color = "\\color{" .. color .. "}"

--- a/example.qmd
+++ b/example.qmd
@@ -20,6 +20,12 @@ This extension allows you to use [academicons](https://jpswalsh.github.io/academ
   {{{< ai <icon-name> <color=...> >}}}
   ```
 
+
+- Optional `<hsize=...>` and `<psize=...>` to specify different sizes for HTML and PDF documents:
+  ``` markdown
+  {{{< ai <icon-name> <hsize=...> <psize=...> >}}}
+  ```
+
 For example:
 
 | Shortcode                          | Icon                           |
@@ -28,6 +34,7 @@ For example:
 | `{{{< ai google-scholar >}}}`      | {{< ai google-scholar >}}      |
 | `{{{< ai open-access >}}}`         | {{< ai open-access >}}         |
 | `{{{< ai open-access size=5x >}}}` | {{< ai open-access size=5x >}} |
-| `{{{< ai open-access size=3em >}}}` | {{< ai open-access size=3em >}} |
+| `{{{< ai open-access size=3x >}}}` | {{< ai open-access size=3x >}} |
+| `{{{< ai open-access hsize=xl psize=Large >}}}` | {{< ai open-access hsize=xl psize=Large >}} |
 | `{{{< ai open-access color=red >}}}` | {{< ai open-access color=red >}} |
 


### PR DESCRIPTION
The main new feature is support for PDF output (tested with LuaLaTeX and XeLaTex). Since this is a significant update, I bumped the version to 0.4.0.

I will submit a corresponding PR to the font-awesome package to keep their features in line.

__Breaking change__: I changed size handling to work as in font-awesome (size is included in the class tag). This required removing the CSS sizing option. The parameter is passed the same as before, but the HTML output will differ. The reasoning is two-fold: maintaining compatibility with the font-awesome extension will make it easier to incorporate updates to that extension. 

Summary of changes:

- Updated referenced academicons version to 1.9.4.
- Added support for TeX output compatible with `academicons` package.
- Change size handling to work as in font-awesome (size is included in the class tag)
- Automatic conversion of PDF sizes to HTML sizes and of _relative_ HTML sizes to PDF size.
- Added support for colors in PDF output.
- Added two optional parameters `hsize` and `psize` to allow different sizes for HTML and PDF output.
- Added two optional parameters, `hcolor` and `pcolor,` to allow different colors for HTML and PDF output.
